### PR TITLE
Add graphviz/mermaid docs

### DIFF
--- a/.github/issues/graphviz_mermaid_documentation.md
+++ b/.github/issues/graphviz_mermaid_documentation.md
@@ -1,0 +1,10 @@
+# Document Graphviz and Mermaid features
+
+## Description
+Currently the documentation does not describe how to generate Graphviz or Mermaid diagrams of a pipeline. The `ezmsg` command-line interface includes `graphviz` and `mermaid` commands, but the docs do not mention them.
+
+## Tasks
+- [ ] Add a section to the docs explaining how to use the `ezmsg graphviz` and `ezmsg mermaid` commands.
+- [ ] Document the optional `--target` parameter for mermaid output.
+- [ ] Provide basic examples demonstrating how to generate and view diagrams.
+

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ https://ezmsg.readthedocs.io/en/latest/
 
 `ezmsg` is very similar to [`labgraph`](https://www.github.com/facebookresearch/labgraph), so you might get a primer with their documentation and examples. Additionally, there are many examples provided in the examples/tests directories strewn throughout this repository.
 
+The command line interface also supports visualizing a running pipeline with
+`ezmsg graphviz` or `ezmsg mermaid`. See the documentation for more details.
+
 ## Extensions
 
 `ezmsg` extensions can be installed individually or all at once. To install all the extension packages in one go, you can use the following command:

--- a/docs/source/graphs.rst
+++ b/docs/source/graphs.rst
@@ -1,0 +1,32 @@
+Graph Visualization
+===================
+
+``ezmsg`` can export the topology of a running pipeline as either a Graphviz or
+Mermaid diagram. These features are exposed through the command line
+interface.
+
+Using ``ezmsg graphviz``
+------------------------
+
+Run ``ezmsg graphviz`` while a pipeline is running to print a Graphviz ``dot``
+representation of the current graph.
+You can redirect this output to a file and then render it with Graphviz tools::
+
+  ezmsg graphviz > pipeline.dot
+  dot -Tpng pipeline.dot -o pipeline.png
+
+Using ``ezmsg mermaid``
+-----------------------
+
+The ``ezmsg mermaid`` command prints a Mermaid diagram. By default it will open
+an online viewer so that the graph is rendered in the browser. The output can
+also be redirected to a file or encoded for `mermaid.ink` or other targets using
+the ``--target`` option.
+
+Example::
+
+  ezmsg mermaid --target live
+
+This will open `https://mermaid.live` with the diagram pre-loaded. Valid targets
+are ``ink`` (for mermaid.ink), ``live`` (default), and ``play`` (mermaidchart.com).
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,6 +26,7 @@ Contents
    about
    api
    utils
+   graphs
    other
    extensions
    developer

--- a/docs/source/other.rst
+++ b/docs/source/other.rst
@@ -6,6 +6,13 @@ Command Line Interface
 
 The ``ezmsg`` command line interface exposes extra tools to manage a pipeline that is running in the background on a machine. Run ``ezmsg -h`` to see all the available options.
 
+Graph Visualization with Graphviz and Mermaid
+---------------------------------------------
+
+You can inspect the connections of a running pipeline using the ``ezmsg graphviz``
+and ``ezmsg mermaid`` commands. See :doc:`graphs` for details on generating and
+viewing these diagrams.
+
 Connecting Two ``ezmsg`` Pipelines
 ----------------------------------
 


### PR DESCRIPTION
## Summary
- create issue for documenting graph visualization commands
- describe graph visualization in docs and reference new page
- mention graphviz/mermaid CLI in README

## Testing
- `pytest -q` *(fails: command not found)*